### PR TITLE
Frontend build Fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ dfx start --background --clean
 npm run gen-deploy
 
 ```
+If building of frontend throws error `dotenv not found ` 
+```bash
+#  run  
+npm install
+```
 
 Once the job completes, your application will be available at `http://localhost:4943?canisterId={asset_canister_id}`.
 


### PR DESCRIPTION
When Running npm run gen-deploy it breaks asking for dotenv file Fixed it by running npm install added the fix of it to the README.md