### PR TITLE
Update player team when adding to team and some improvements

### DIFF
--- a/src/fantasy_sports_platform_backend/fantasy_sports_platform_backend.did
+++ b/src/fantasy_sports_platform_backend/fantasy_sports_platform_backend.did
@@ -1,4 +1,7 @@
-type Error = variant { NotFound : record { msg : text } };
+type Error = variant {
+  InvalidInputData : record { msg : text };
+  NotFound : record { msg : text };
+};
 type League = record { id : nat64; teams : vec TeamLineup; name : text };
 type LeaguePayload = record { name : text };
 type Player = record {


### PR DESCRIPTION
## Improvement and Fixes

1. Implemented a check for the age input field in the update_player function to ensure that the conditions used in the add_player function are still maintained to prevent unexpected issues such as a player being listed with an invalid age such as 55.
2. I've noticed that a player's team field wasn't updated whenever that player was added to a team, so I've gone ahead and implemented a few lines of code to update the team field of a player whenever the add_player_to_team function is successfully called
3. I've moved the check that ensured that a player wasn't already part of the team after the checks carried to ensure that a player with player_id exists to optimize the function as this check should only be run if the player exists.
4. Removed the unnecessary lines left in some parts of the code where there was an empty line between the functions attribute macros and the declaration of the functions to improve readability.